### PR TITLE
chore: improvements on code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,8 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-indent_style = space
+indent_size = 2
+indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
@@ -15,4 +15,4 @@ trim_trailing_whitespace = false
 indent_size = 2
 
 [docker-compose.yml]
-indent_size = 4
+indent_size = 2

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,8 +11,8 @@
   },
   "plugins": ["react"],
   "rules": {
-    "indent": ["error", "tab"],
-    "linebreak-style": ["error", "unix"],
+		"prettier/prettier": "error",
+		"react/prop-types": ["off"],
     "quotes": ["error", "single"],
     "semi": ["error", "never"]
   }


### PR DESCRIPTION
### Objetivo
- Adicionar melhorias no estilo de espaçamento/identação do código:

Antes:
<img width="1316" alt="CleanShot 2023-05-05 at 23 19 26@2x" src="https://user-images.githubusercontent.com/69880411/236593479-c739b956-2f4a-4b9d-8f95-dca41234f3d8.png">

Depois:
![CleanShot 2023-05-05 at 23 21 14@2x](https://user-images.githubusercontent.com/69880411/236593541-81ad525e-be43-4834-a66c-886b8dab64bf.png)

⚠️ Necessário ter a extensão **ESLINT** habilitada.